### PR TITLE
Add a Python SDK facade and a frustrapy command-line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ uv pip install -e ".[viz]"         # 3D viewers (py3Dmol) + static PNG export (k
 uv pip install -e ".[clustering]"  # detect_dynamic_clusters (scipy/sklearn/igraph/leidenalg/statsmodels)
 uv pip install -e ".[perf]"        # memory logging (psutil)
 uv pip install -e ".[pyrosetta]"   # pyrosetta-installer helper for the PyRosetta mutation backend
+uv pip install -e ".[cli]"         # the `frustrapy` command-line tool (Typer + Rich)
 uv pip install -e ".[all]"         # everything above
 ```
 
@@ -175,6 +176,31 @@ plots_by_pdb, density = frustrapy.dir_frustration(
     n_procs=4,   # process structures concurrently under a shared core budget
 )
 ```
+
+## Command-line tool
+
+Installing the `cli` extra (`uv pip install -e ".[cli]"`) exposes a `frustrapy`
+console command — thin wrappers over the same functions used above, with a styled
+Rich interface. The extra adds `typer` for argument parsing (`rich` is already a
+core dependency); `frustrapy/cli/main.py` imports `typer` lazily, so the core
+library never requires it and plain `import frustrapy` works without the extra.
+
+```bash
+frustrapy --version
+frustrapy --help            # lists every subcommand
+frustrapy single --help     # per-subcommand help
+```
+
+| Subcommand | What it runs | Example |
+|---|---|---|
+| `single` | one PDB through one mode (`calculate_frustration`) | `frustrapy single protein.pdb -m configurational -o results` |
+| `batch` | every `.pdb` in a directory (`dir_frustration`) | `frustrapy batch pdbs/ -m configurational -o results --n-procs 4` |
+| `evo` | evolutionary frustration for a family (`analyze_family`) | `frustrapy evo family.fasta -j fam1 -p pdbs/ -r 3lqd-A -o results` |
+| `mutate` | saturation-mutagenesis scan of one residue (`mutate_res_parallel`) | `frustrapy mutate protein.pdb --res 10 -c A --method threading -o results` |
+
+Each subcommand writes the same on-disk output described below, prints a summary
+panel/table, and returns a non-zero exit code with an actionable error message on
+failure. Run any subcommand with `--help` for the full option list.
 
 ## Output contract
 

--- a/frustrapy/cli/__init__.py
+++ b/frustrapy/cli/__init__.py
@@ -1,0 +1,12 @@
+"""Command-line interface for FrustraPy.
+
+The CLI is an optional component: it depends on ``typer`` (and ``rich``, already a
+core dependency) which ship in the ``cli`` extra::
+
+    pip install "frustrapy[cli]"
+
+The console-script entry point is :func:`frustrapy.cli.main.main`. Importing this
+subpackage does not import ``typer``; the core library never requires it. The
+top-level ``frustrapy`` package does not import this module, so ``import frustrapy``
+stays free of any CLI dependency.
+"""

--- a/frustrapy/cli/main.py
+++ b/frustrapy/cli/main.py
@@ -1,0 +1,403 @@
+"""``frustrapy`` command-line tool.
+
+Thin Typer wrappers over the :mod:`frustrapy.sdk` facade — every subcommand parses
+arguments, calls one SDK function, and renders the result with Rich. No analysis
+logic lives here.
+
+Subcommands
+-----------
+* ``single``  — one PDB through one frustration mode (``calculate_frustration``).
+* ``batch``   — every PDB in a directory (``dir_frustration``).
+* ``evo``     — evolutionary frustration for a protein family (``analyze_family``).
+* ``mutate``  — saturation-mutagenesis scan of one residue (``mutate_res_parallel``).
+
+``typer`` is imported lazily so that merely importing this module on a bare install
+fails gracefully with an actionable message instead of an opaque ``ImportError``.
+The core library never imports this module, so ``import frustrapy`` does not require
+``typer``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+# The CLI extra (`pip install "frustrapy[cli]"`) provides typer; rich is already a
+# core dependency. Guard the import so the console script can print a helpful hint
+# rather than a raw traceback when the extra is missing.
+try:
+    import typer
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+
+    _CLI_IMPORT_ERROR: Optional[BaseException] = None
+except ImportError as exc:  # pragma: no cover - exercised only on a bare install
+    typer = None  # type: ignore[assignment]
+    _CLI_IMPORT_ERROR = exc
+
+
+# Frustration classes carried in the FrstState column of contact tables, in the
+# order we want them displayed.
+_FRST_STATES = ("minimally", "neutral", "highly")
+
+
+if typer is not None:
+    console = Console()
+    err_console = Console(stderr=True)
+
+    app = typer.Typer(
+        name="frustrapy",
+        help=(
+            "Compute local energetic frustration in protein structures "
+            "(a Python reimplementation of frustratometeR)."
+        ),
+        add_completion=False,
+        no_args_is_help=True,
+        rich_markup_mode="rich",
+    )
+
+    def _version_callback(value: bool) -> None:
+        if value:
+            from frustrapy import __version__
+
+            console.print(f"frustrapy {__version__}")
+            raise typer.Exit()
+
+    @app.callback()
+    def _main(
+        version: bool = typer.Option(
+            False,
+            "--version",
+            "-V",
+            help="Show the installed FrustraPy version and exit.",
+            callback=_version_callback,
+            is_eager=True,
+        ),
+    ) -> None:
+        """FrustraPy — local energetic frustration analysis."""
+
+    # ----------------------------------------------------------------------- #
+    # Helpers
+    # ----------------------------------------------------------------------- #
+    def _fail(message: str, code: int = 1) -> "typer.Exit":
+        """Render an error panel and return an Exit carrying ``code``."""
+        err_console.print(
+            Panel(message, title="Error", border_style="red", expand=False)
+        )
+        return typer.Exit(code)
+
+    def _summary_table(df, mode: str) -> Table:
+        """Build a Rich table summarising one frustration result."""
+        table = Table(title=f"Frustration summary ({mode})", expand=False)
+        table.add_column("Metric", style="cyan", no_wrap=True)
+        table.add_column("Value", style="white")
+        n_rows = len(df)
+        unit = "residues" if mode == "singleresidue" else "contacts"
+        table.add_row(f"Scored {unit}", str(n_rows))
+        if "FrstState" in df.columns and n_rows:
+            counts = df["FrstState"].value_counts()
+            for state in _FRST_STATES:
+                n = int(counts.get(state, 0))
+                pct = 100.0 * n / n_rows if n_rows else 0.0
+                table.add_row(f"{state} frustrated", f"{n}  ({pct:.1f}%)")
+        return table
+
+    # ----------------------------------------------------------------------- #
+    # single
+    # ----------------------------------------------------------------------- #
+    @app.command()
+    def single(
+        pdb_file: Path = typer.Argument(
+            ..., exists=True, dir_okay=False, readable=True, help="Input PDB file."
+        ),
+        mode: str = typer.Option(
+            "configurational",
+            "--mode",
+            "-m",
+            help="Frustration index: configurational, mutational, or singleresidue.",
+        ),
+        seq_dist: int = typer.Option(
+            12, "--seq-dist", help="Sequence separation for contacts (3 or 12)."
+        ),
+        chain: Optional[str] = typer.Option(
+            None, "--chain", "-c", help="Restrict analysis to this chain."
+        ),
+        results_dir: Optional[Path] = typer.Option(
+            None, "--results-dir", "-o", help="Output directory (default: cwd)."
+        ),
+        graphics: bool = typer.Option(
+            False, "--graphics/--no-graphics", help="Generate Plotly graphics."
+        ),
+        n_cpus: Optional[int] = typer.Option(
+            None, "--n-cpus", help="CPU cores for the mutation pool (singleresidue)."
+        ),
+    ) -> None:
+        """Run one PDB through one frustration mode."""
+        import frustrapy.sdk as fp
+
+        if mode not in ("configurational", "mutational", "singleresidue"):
+            raise _fail(
+                f"Unknown mode '{mode}'. Choose configurational, mutational, "
+                "or singleresidue."
+            )
+        if seq_dist not in (3, 12):
+            raise _fail(f"--seq-dist must be 3 or 12, got {seq_dist}.")
+
+        with console.status(
+            f"[bold]Computing {mode} frustration for {pdb_file.name}…", spinner="dots"
+        ):
+            try:
+                pdb, _plots, _density, _single = fp.calculate_frustration(
+                    pdb_file=str(pdb_file),
+                    mode=mode,
+                    seq_dist=seq_dist,
+                    chain=chain,
+                    results_dir=str(results_dir) if results_dir else None,
+                    graphics=graphics,
+                    visualization=graphics,
+                    debug="ERROR",
+                )
+            except Exception as exc:  # surface the failure as a clean message
+                raise _fail(f"Frustration calculation failed: {exc}")
+
+        try:
+            df = fp.get_frustration(pdb)
+            console.print(_summary_table(df, mode))
+        except Exception:  # the run succeeded even if the summary read did not
+            pass
+        console.print(
+            Panel(
+                f"Output written to [bold]{pdb.job_dir}[/bold]\n"
+                f"Tables under FrustrationData/",
+                title="Done",
+                border_style="green",
+                expand=False,
+            )
+        )
+
+    # ----------------------------------------------------------------------- #
+    # batch
+    # ----------------------------------------------------------------------- #
+    @app.command()
+    def batch(
+        pdbs_dir: Path = typer.Argument(
+            ...,
+            exists=True,
+            file_okay=False,
+            readable=True,
+            help="Directory of PDB files.",
+        ),
+        mode: str = typer.Option(
+            "configurational", "--mode", "-m", help="Frustration index."
+        ),
+        seq_dist: int = typer.Option(
+            12, "--seq-dist", help="Sequence separation for contacts (3 or 12)."
+        ),
+        results_dir: Optional[Path] = typer.Option(
+            None, "--results-dir", "-o", help="Output directory (default: cwd)."
+        ),
+        n_procs: Optional[int] = typer.Option(
+            None, "--n-procs", help="Structures to process concurrently."
+        ),
+        n_cpus: Optional[int] = typer.Option(
+            None, "--n-cpus", help="Inner CPU budget per structure."
+        ),
+        graphics: bool = typer.Option(
+            False, "--graphics/--no-graphics", help="Generate Plotly graphics."
+        ),
+    ) -> None:
+        """Run every PDB in a directory."""
+        import frustrapy.sdk as fp
+
+        if mode not in ("configurational", "mutational", "singleresidue"):
+            raise _fail(f"Unknown mode '{mode}'.")
+        if seq_dist not in (3, 12):
+            raise _fail(f"--seq-dist must be 3 or 12, got {seq_dist}.")
+
+        pdbs = sorted(p.name for p in pdbs_dir.glob("*.pdb"))
+        if not pdbs:
+            raise _fail(f"No .pdb files found in {pdbs_dir}.")
+
+        with console.status(
+            f"[bold]Computing {mode} frustration for {len(pdbs)} structures…",
+            spinner="dots",
+        ):
+            try:
+                fp.dir_frustration(
+                    pdbs_dir=str(pdbs_dir),
+                    mode=mode,
+                    seq_dist=seq_dist,
+                    results_dir=str(results_dir) if results_dir else None,
+                    graphics=graphics,
+                    visualization=graphics,
+                    n_procs=n_procs,
+                    n_cpus=n_cpus,
+                    debug=False,
+                )
+            except Exception as exc:
+                raise _fail(f"Batch frustration failed: {exc}")
+
+        out = results_dir if results_dir else Path.cwd()
+        console.print(
+            Panel(
+                f"Processed [bold]{len(pdbs)}[/bold] structures.\n"
+                f"Output under [bold]{out}[/bold]",
+                title="Done",
+                border_style="green",
+                expand=False,
+            )
+        )
+
+    # ----------------------------------------------------------------------- #
+    # evo
+    # ----------------------------------------------------------------------- #
+    @app.command()
+    def evo(
+        fasta_file: Path = typer.Argument(
+            ..., exists=True, dir_okay=False, readable=True, help="MSA in FASTA format."
+        ),
+        job_id: str = typer.Option(..., "--job-id", "-j", help="Analysis identifier."),
+        pdb_dir: Path = typer.Option(
+            ...,
+            "--pdb-dir",
+            "-p",
+            exists=True,
+            file_okay=False,
+            help="Directory of per-member PDB files.",
+        ),
+        reference_pdb: Optional[str] = typer.Option(
+            None, "--reference-pdb", "-r", help="Reference member identifier."
+        ),
+        results_dir: Optional[Path] = typer.Option(
+            None, "--results-dir", "-o", help="Output directory."
+        ),
+        contact_maps: bool = typer.Option(
+            False, "--contact-maps", help="Generate contact-map plots."
+        ),
+        n_procs: Optional[int] = typer.Option(
+            None, "--n-procs", help="Per-structure calculations to run concurrently."
+        ),
+    ) -> None:
+        """Evolutionary frustration for a protein family (FrustraEvo)."""
+        import frustrapy.sdk as fp
+
+        with console.status(
+            f"[bold]Analyzing family '{job_id}'…", spinner="dots"
+        ):
+            try:
+                result = fp.analyze_family(
+                    fasta_file=str(fasta_file),
+                    job_id=job_id,
+                    reference_pdb=reference_pdb,
+                    pdb_dir=str(pdb_dir),
+                    contact_maps=contact_maps,
+                    results_dir=str(results_dir) if results_dir else None,
+                    n_procs=n_procs,
+                )
+            except Exception as exc:
+                raise _fail(f"Family analysis failed: {exc}")
+
+        table = Table(title=f"FrustraEvo summary ({job_id})", expand=False)
+        table.add_column("Metric", style="cyan", no_wrap=True)
+        table.add_column("Value", style="white")
+        summary = {}
+        if isinstance(result, dict):
+            summary = result.get("contacts", {}).get("summary", {})
+        for label, key in (
+            ("total contacts", "total_contacts"),
+            ("minimally frustrated", "minimally_frustrated"),
+            ("neutrally frustrated", "neutrally_frustrated"),
+            ("maximally frustrated", "maximally_frustrated"),
+        ):
+            if key in summary:
+                table.add_row(label, str(summary[key]))
+        out = result.get("output_dir") if isinstance(result, dict) else None
+        console.print(table)
+        console.print(
+            Panel(
+                f"Output written to [bold]{out}[/bold]",
+                title="Done",
+                border_style="green",
+                expand=False,
+            )
+        )
+
+    # ----------------------------------------------------------------------- #
+    # mutate
+    # ----------------------------------------------------------------------- #
+    @app.command()
+    def mutate(
+        pdb_file: Path = typer.Argument(
+            ..., exists=True, dir_okay=False, readable=True, help="Input PDB file."
+        ),
+        res: int = typer.Option(..., "--res", help="Residue number to scan."),
+        chain: str = typer.Option("A", "--chain", "-c", help="Chain of the residue."),
+        method: str = typer.Option(
+            "threading",
+            "--method",
+            help="Mutation backend: threading, modeller, or pyrosetta.",
+        ),
+        results_dir: Optional[Path] = typer.Option(
+            None, "--results-dir", "-o", help="Output directory."
+        ),
+        n_cpus: Optional[int] = typer.Option(
+            None, "--n-cpus", help="CPU cores for the mutation pool."
+        ),
+    ) -> None:
+        """Saturation-mutagenesis scan of one residue (all 20 amino acids)."""
+        import frustrapy.sdk as fp
+
+        if method not in ("threading", "modeller", "pyrosetta"):
+            raise _fail(
+                f"Unknown method '{method}'. Choose threading, modeller, "
+                "or pyrosetta."
+            )
+
+        with console.status(
+            f"[bold]Scanning residue {res}{chain} ({method})…", spinner="dots"
+        ):
+            try:
+                pdb, _plots, _density, _single = fp.calculate_frustration(
+                    pdb_file=str(pdb_file),
+                    mode="singleresidue",
+                    residues={chain: [res]},
+                    results_dir=str(results_dir) if results_dir else None,
+                    graphics=False,
+                    visualization=False,
+                    debug="ERROR",
+                )
+                fp.mutate_res_parallel(
+                    pdb, res_num=res, chain=chain, method=method, n_cpus=n_cpus
+                )
+            except Exception as exc:
+                raise _fail(f"Mutation scan failed: {exc}")
+
+        out = Path(pdb.job_dir) / "MutationsData"
+        console.print(
+            Panel(
+                f"Scanned residue [bold]{res}{chain}[/bold] over 20 amino acids "
+                f"({method}).\nOutput under [bold]{out}[/bold]",
+                title="Done",
+                border_style="green",
+                expand=False,
+            )
+        )
+
+
+def main() -> None:
+    """Console-script entry point (``frustrapy``)."""
+    if typer is None:
+        import sys
+
+        sys.stderr.write(
+            "The frustrapy CLI requires the 'cli' extra.\n"
+            "Install it with:  pip install \"frustrapy[cli]\"\n"
+            f"(import error: {_CLI_IMPORT_ERROR})\n"
+        )
+        raise SystemExit(1)
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/frustrapy/sdk.py
+++ b/frustrapy/sdk.py
@@ -1,0 +1,111 @@
+"""Public Python SDK for FrustraPy.
+
+This module is a thin, documented facade over the functions that already make up
+the FrustraPy public API. It does not reimplement or wrap any logic; it groups the
+stable entry points behind one import so application and notebook code has a single,
+typed surface to depend on::
+
+    import frustrapy.sdk as fp
+
+    pdb, plots, density, single_res = fp.calculate_frustration(
+        pdb_file="1crn.pdb", mode="configurational"
+    )
+    table = fp.get_frustration(pdb)
+
+Every name re-exported here is the same callable exposed at the top level of the
+``frustrapy`` package, so ``frustrapy.calculate_frustration`` and
+``frustrapy.sdk.calculate_frustration`` are the same object. The facade exists to
+give a single documented place that describes the public surface and its return
+contracts; the top-level names remain for backwards compatibility.
+
+Return contracts
+----------------
+``calculate_frustration`` returns a 4-tuple
+``(Pdb, plots: dict, density: FrustrationDensityResults | None, single_residue: dict | None)``.
+The density slot is populated only in ``singleresidue`` mode with a non-empty
+``residues`` selection; otherwise it is ``None``. The fourth slot is the parsed
+single-residue data, also only populated in ``singleresidue`` mode.
+
+``dir_frustration`` returns ``(plots: dict, density: FrustrationDensityResults | None)``.
+
+``dynamic_frustration`` returns a :class:`~frustrapy.core.dynamic.Dynamic` object.
+
+``get_frustration`` returns a :class:`pandas.DataFrame` parsed from the on-disk
+frustration table (14 columns for configurational/mutational, 8 for singleresidue).
+
+``analyze_family`` returns a ``dict`` with ``job_id``, ``output_dir``, a ``files``
+sub-dict of output paths, and a ``contacts`` sub-dict of per-contact information
+content plus MIN/NEU/MAX summary counts.
+
+The mutation-scan functions return the input :class:`~frustrapy.core.pdb.Pdb` with
+``pdb.Mutations[method]`` and ``pdb.MutationAnalysis`` populated.
+
+Modes and thresholds
+--------------------
+Three frustration indices are supported via ``mode``: ``"configurational"``,
+``"mutational"``, ``"singleresidue"``. Contact tables (configurational/mutational)
+classify ``FrstIndex <= -1`` as highly frustrated, ``>= 0.78`` as minimally
+frustrated, and the interval between as neutral.
+"""
+
+from __future__ import annotations
+
+# Version of the installed package, mirrored from the top-level namespace.
+from . import __version__
+
+# --- Single-structure frustration -----------------------------------------
+# calculate_frustration: run one structure through the AWSEM/LAMMPS engine and
+# parse its tables. get_frustration: read back the parsed per-residue/per-contact
+# table for a finished Pdb, optionally filtered by residue or chain.
+from .analysis.frustration import (
+    calculate_frustration,
+    get_frustration,
+)
+
+# --- Batch and trajectory --------------------------------------------------
+# dir_frustration: every PDB in a directory (n_procs runs structures concurrently).
+# dynamic_frustration: an ordered set of trajectory frames -> a Dynamic object.
+from .analysis.frustration import (
+    dir_frustration,
+    dynamic_frustration,
+)
+
+# --- Saturation mutagenesis ------------------------------------------------
+# mutate_res_scan_parallel: the whole (residue x amino-acid) grid in one pool.
+# mutate_res_parallel: single-residue convenience wrapper over the scan.
+# pyrosetta_available: report whether the optional PyRosetta backend is installed.
+from .analysis.mutations import (
+    mutate_res_parallel,
+    mutate_res_scan_parallel,
+)
+from .analysis.mutation_backends import pyrosetta_available
+
+# --- Evolutionary frustration (FrustraEvo) ---------------------------------
+from .evolution import analyze_family
+
+# --- Return-contract types -------------------------------------------------
+# Re-exported so callers can annotate against the SDK's return types without
+# reaching into private submodules.
+from .core.pdb import Pdb
+from .core.dynamic import Dynamic
+from .core.data_classes import FrustrationDensityResults
+
+__all__ = [
+    "__version__",
+    # single-structure
+    "calculate_frustration",
+    "get_frustration",
+    # batch / trajectory
+    "dir_frustration",
+    "dynamic_frustration",
+    # mutation scan
+    "mutate_res_parallel",
+    "mutate_res_scan_parallel",
+    "pyrosetta_available",
+    # evolution
+    "analyze_family",
+    # types
+    "Pdb",
+    "Dynamic",
+    "FrustrationDensityResults",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,15 @@ clustering = ["scipy", "scikit-learn", "python-igraph", "leidenalg", "statsmodel
 # to download and install the licensed PyRosetta wheel. Imported lazily inside the
 # mutation worker; a bare install keeps method='threading' fully functional.
 pyrosetta = ["pyrosetta-installer"]
-all = ["frustrapy[viz,perf,clustering]"]
+# Terminal CLI (`frustrapy` console script). typer drives arg parsing + rich help;
+# rich (already core) renders progress/tables/panels. Imported lazily by
+# frustrapy/cli/main.py so the core library never requires typer — `import frustrapy`
+# stays CLI-free.
+cli = ["typer>=0.12"]
+all = ["frustrapy[viz,perf,clustering,cli]"]
+
+[project.scripts]
+frustrapy = "frustrapy.cli.main:main"
 
 [project.urls]
 Homepage = "https://github.com/engelberger/frustrapy"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,171 @@
+"""Tests for the ``frustrapy`` command-line tool (``frustrapy.cli.main``).
+
+Two lanes, mirroring the rest of the suite:
+
+* **fast** — exercised entirely in-process via Typer's :class:`CliRunner` without
+  touching the LAMMPS/AWSEM engine: ``--help`` for the app and every subcommand,
+  ``--version``, and one argument-validation error path per subcommand.
+* **slow** (``@pytest.mark.slow``) — drive each subcommand end-to-end on a small
+  fixture (1CRN / the 3-member evo_smoke family), assert it exits 0 and writes the
+  expected output tree. These run the real toolchain, so — like the rest of the e2e
+  lane — they need the project virtualenv on PATH (see ``tests/conftest.py``).
+
+The CLI is a thin Typer wrapper over :mod:`frustrapy.sdk`; these tests check the
+wiring (arg parsing, exit codes, output location), not the frustration numbers,
+which are locked by the parity/anchor tests.
+"""
+
+import os
+import warnings
+
+import pytest
+
+from typer.testing import CliRunner
+
+from frustrapy.cli.main import app
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+CRN_PDB = os.path.join(DATA_DIR, "1crn.pdb")
+EVO_DIR = os.path.join(DATA_DIR, "evo_smoke")
+EVO_FASTA = os.path.join(EVO_DIR, "family.fasta")
+EVO_REFERENCE = "3lqd-A"
+
+runner = CliRunner()
+
+
+# --------------------------------------------------------------------------- #
+# fast lane — help / version / argument validation (no engine)
+# --------------------------------------------------------------------------- #
+def test_app_help_lists_every_subcommand():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for sub in ("single", "batch", "evo", "mutate"):
+        assert sub in result.output
+
+
+def test_version_flag():
+    import frustrapy
+
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert frustrapy.__version__ in result.output
+
+
+@pytest.mark.parametrize("sub", ["single", "batch", "evo", "mutate"])
+def test_subcommand_help(sub):
+    """Every subcommand renders its own ``--help`` and exits 0."""
+    result = runner.invoke(app, [sub, "--help"])
+    assert result.exit_code == 0
+    assert "Usage" in result.output
+
+
+def test_single_rejects_unknown_mode():
+    result = runner.invoke(app, ["single", CRN_PDB, "--mode", "bogus"])
+    assert result.exit_code == 1
+
+
+def test_single_rejects_bad_seq_dist():
+    result = runner.invoke(app, ["single", CRN_PDB, "--seq-dist", "7"])
+    assert result.exit_code == 1
+
+
+def test_single_missing_file_is_usage_error():
+    """Typer's ``exists=True`` rejects a nonexistent PDB before any work (exit 2)."""
+    result = runner.invoke(app, ["single", os.path.join(DATA_DIR, "nope.pdb")])
+    assert result.exit_code == 2
+
+
+def test_batch_empty_directory(tmp_path):
+    result = runner.invoke(app, ["batch", str(tmp_path)])
+    assert result.exit_code == 1
+
+
+def test_mutate_rejects_unknown_method():
+    result = runner.invoke(app, ["mutate", CRN_PDB, "--res", "10", "--method", "bogus"])
+    assert result.exit_code == 1
+
+
+def test_evo_missing_fasta_is_usage_error(tmp_path):
+    """A missing FASTA is rejected by Typer's ``exists=True`` (exit 2)."""
+    result = runner.invoke(
+        app,
+        [
+            os.path.join(DATA_DIR, "nope.fasta"),
+            "--job-id",
+            "x",
+            "--pdb-dir",
+            str(tmp_path),
+        ],
+    )
+    # First positional is the (missing) FASTA -> usage error, no engine run.
+    assert result.exit_code == 2
+
+
+# --------------------------------------------------------------------------- #
+# slow lane — end-to-end on small fixtures (runs the real engine)
+# --------------------------------------------------------------------------- #
+@pytest.mark.slow
+def test_single_end_to_end(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = runner.invoke(
+            app,
+            ["single", CRN_PDB, "--mode", "configurational", "-o", str(tmp_path)],
+        )
+    assert result.exit_code == 0, result.output
+    table = tmp_path / "1crn.done" / "FrustrationData" / "1crn.pdb_configurational"
+    assert table.exists(), f"missing output table: {table}"
+
+
+@pytest.mark.slow
+def test_batch_end_to_end(tmp_path):
+    import shutil
+
+    pdbs_dir = tmp_path / "pdbs"
+    pdbs_dir.mkdir()
+    shutil.copy(CRN_PDB, pdbs_dir / "1crn.pdb")
+    out = tmp_path / "out"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = runner.invoke(
+            app,
+            ["batch", str(pdbs_dir), "--mode", "configurational", "-o", str(out)],
+        )
+    assert result.exit_code == 0, result.output
+    table = out / "1crn.done" / "FrustrationData" / "1crn.pdb_configurational"
+    assert table.exists(), f"missing output table: {table}"
+
+
+@pytest.mark.slow
+def test_mutate_end_to_end(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = runner.invoke(
+            app,
+            ["mutate", CRN_PDB, "--res", "10", "--chain", "A", "-o", str(tmp_path)],
+        )
+    assert result.exit_code == 0, result.output
+    mut_dir = tmp_path / "1crn.done" / "MutationsData"
+    assert mut_dir.exists(), f"missing MutationsData dir: {mut_dir}"
+
+
+@pytest.mark.slow
+def test_evo_end_to_end(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = runner.invoke(
+            app,
+            [
+                "evo",
+                EVO_FASTA,
+                "--job-id",
+                "evo_smoke",
+                "--pdb-dir",
+                EVO_DIR,
+                "--reference-pdb",
+                EVO_REFERENCE,
+                "-o",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0, result.output

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,73 @@
+"""Smoke tests for the public SDK facade (``frustrapy.sdk``).
+
+These do not run the LAMMPS engine; they check that the facade imports, exposes the
+documented public surface, and re-exports the same callables as the top-level
+``frustrapy`` package (the facade must not shadow or diverge from the existing API).
+"""
+
+import frustrapy
+from frustrapy import sdk
+
+
+# The names the facade promises to expose. Kept in sync with sdk.__all__.
+EXPECTED_NAMES = {
+    "calculate_frustration",
+    "get_frustration",
+    "dir_frustration",
+    "dynamic_frustration",
+    "mutate_res_parallel",
+    "mutate_res_scan_parallel",
+    "pyrosetta_available",
+    "analyze_family",
+    "Pdb",
+    "Dynamic",
+    "FrustrationDensityResults",
+}
+
+
+def test_all_names_present():
+    """Every documented name is importable from the facade."""
+    for name in EXPECTED_NAMES:
+        assert hasattr(sdk, name), f"frustrapy.sdk is missing {name!r}"
+    assert EXPECTED_NAMES.issubset(set(sdk.__all__))
+
+
+def test_facade_matches_toplevel():
+    """Names shared with the top-level package are the SAME object, not a copy.
+
+    This is what makes the facade a non-breaking organization of the existing API
+    rather than a parallel reimplementation.
+    """
+    for name in [
+        "calculate_frustration",
+        "get_frustration",
+        "dir_frustration",
+        "dynamic_frustration",
+        "mutate_res_parallel",
+        "analyze_family",
+        "Pdb",
+        "Dynamic",
+    ]:
+        assert getattr(sdk, name) is getattr(frustrapy, name), name
+
+
+def test_version_mirrored():
+    """The facade exposes the same version string as the package."""
+    assert sdk.__version__ == frustrapy.__version__
+
+
+def test_callables_are_callable():
+    """The re-exported entry points are callable and the types are classes."""
+    for name in [
+        "calculate_frustration",
+        "get_frustration",
+        "dir_frustration",
+        "dynamic_frustration",
+        "mutate_res_parallel",
+        "mutate_res_scan_parallel",
+        "pyrosetta_available",
+        "analyze_family",
+    ]:
+        assert callable(getattr(sdk, name)), name
+    for name in ["Pdb", "Dynamic", "FrustrationDensityResults"]:
+        assert isinstance(getattr(sdk, name), type), name


### PR DESCRIPTION
Add a documented Python SDK facade and a `frustrapy` command-line tool.

SDK (`frustrapy/sdk.py`)
- A small, typed, documented facade over the existing API (single-structure
  calculation, directory batch, evolution, and the mutation backends). It wraps the
  existing functions; it does not change their behavior.

CLI (`frustrapy/cli/main.py`, Typer + Rich)
- A `frustrapy` console-script entry point with subcommands `single`, `batch`, `evo`
  and `mutate`, each a thin wrapper over the SDK.
- Rich help, progress indication on long runs, styled result summaries, argument
  validation with clear errors and conventional exit codes, and `--version`.
- `typer` is a `cli`-extra dependency, lazy-imported so the core library does not
  require it; `rich` is already a core dependency.

Tests and docs
- `tests/test_cli.py`: Typer `CliRunner` coverage — 12 fast tests (help/version and
  one argument-error path per subcommand) and 4 slow end-to-end tests (one per
  subcommand on 1CRN / the small evolution fixture).
- `tests/test_sdk.py`: SDK smoke coverage.
- README: a `[cli]` install extra and a command-line section with a subcommand table.

Base branch is `staging` so this shows only the SDK/CLI diff.
