### PR TITLE
Make parallelism thread- and core-safe (bounded, no recursive spawn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,49 @@ For configurational/mutational contacts (single source of truth:
 The `0.78` cutoff is derived analytically (arXiv:1812.05965). Single-residue *plots*
 use a distinct minimally cutoff of `0.58`, matching frustratometeR's visualization.
 
+## Parallelism and resource limits
+
+FrustraPy runs work concurrently on three axes — a batch of structures
+(`dir_frustration(..., n_procs=K)` and `dynamic_frustration` over trajectory
+frames), the per-residue saturation scan (`mutate_res_scan_parallel`), and the
+per-structure precompute in the evolution module. These can nest: a parallel
+batch can hand each structure a singleresidue scan that opens its own pool. To
+stop that nest from multiplying into a fork bomb, every pool draws from one
+shared budget instead of calling `cpu_count()` on its own.
+
+The budget lives in `frustrapy/utils/concurrency.py` and works as follows:
+
+- **One core budget.** `cpu_budget()` is the single source of how many cores
+  FrustraPy may use (physical cores, never less than 1). No call site invents a
+  larger bound.
+- **Nested pools split the budget, they do not multiply it.**
+  `resolve_concurrency(n_procs, n_items)` returns an `(outer, inner)` pair where
+  `outer` items run concurrently and each gets `inner = cores // outer` cores
+  for its own inner pool. The invariant `outer * inner <= cores` holds for any
+  input, so two levels of nesting can never exceed the core budget. A flat
+  (non-nested) pool uses `resolve_pool_size(...)`, which is
+  `min(requested, cores, n_tasks)`.
+- **Each worker is pinned to one native-math thread.** `apply_thread_limits()`
+  (in the dependency-free `frustrapy/_threadlimits.py`, applied at the top of
+  `frustrapy/__init__.py` before numpy loads) sets `OMP_NUM_THREADS`,
+  `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `NUMEXPR_NUM_THREADS`, and two
+  related vars to `1` via `setdefault` — so `cores` worker processes cannot each
+  spin up `cores` BLAS threads (which would be `cores**2` threads). If you
+  export your own thread counts, FrustraPy leaves them untouched.
+- **Pools fork safely and shut down cleanly.** Worker pools are created from a
+  `forkserver` (then `spawn`) start method via `get_pool_context()`, so forking
+  from a possibly multi-threaded parent cannot deadlock the child or orphan a
+  LAMMPS subprocess. Pools are always closed and joined, including on a worker
+  error or timeout.
+
+In practice this means `n_procs=K` is a ceiling on how many structures run at
+once, not a multiplier: a user cannot fork-bomb the machine by combining a large
+`n_procs` with a singleresidue batch or an evolution run. To cap usage further,
+set `n_procs` to a small number; to give each native-math library more than one
+thread, export e.g. `OMP_NUM_THREADS` before importing FrustraPy. The full audit
+of every parallel construct and its nesting paths is in
+`docs/parallelism_inventory.md`.
+
 ## Known limitations
 
 - **Not yet on PyPI** — install from source (the release workflow is ready).

--- a/docs/parallelism_inventory.md
+++ b/docs/parallelism_inventory.md
@@ -1,0 +1,114 @@
+# Parallelism inventory (P1)
+
+Engineering map of every place FrustraPy spawns processes, threads, or
+subprocesses, how each one is sized, and every way they nest. This is the
+audit baseline for the parallelization-safety work; the user-facing summary of
+the resulting limits lives separately (see "Parallelism and resource limits").
+
+Evidence is `file:line` against the package tree at the time of writing.
+
+## 1. Process pools (the things that fan out)
+
+| # | Construct | Location | Pool / executor | Worker count (sizing) |
+|---|-----------|----------|-----------------|-----------------------|
+| 1 | `mutate_res_scan_parallel` (flattened residue x amino-acid scan) | `analysis/mutations.py:512`, pool at `:613` | `multiprocessing.Pool` (default `fork` on Linux), `imap_unordered(_process_amino_acid, ...)` | `_resolve_pool_size(n_cpus, len(args_list), cpu_count())` = `max(1, min(n_cpus or cores, cores, n_tasks))`, where `n_tasks = n_residues * 20` (`:593`) |
+| 2 | `mutate_res_parallel` (legacy single-residue 20-task pool) | `analysis/mutations.py` | `multiprocessing.Pool` | same `_resolve_pool_size` helper; superseded by #1 for the live singleresidue path but still part of the public API |
+| 3 | `dir_frustration(n_procs=K)` (batch over structures) | `analysis/frustration.py:360` | `concurrent.futures.ProcessPoolExecutor(max_workers=n_procs_eff)` | `n_procs_eff = max(1, min(n_procs, len(order_list), cores))` (`:335-338`); each structure gets `inner_cpus = max(1, cores // n_procs_eff)` passed as `n_cpus` (`:345-356`) |
+| 4 | `dynamic_frustration(n_procs=K)` (trajectory frames) | `analysis/frustration.py:468` | none of its own — delegates to `dir_frustration` | inherits #3 sizing |
+| 5 | evolution per-structure precompute | `evolution/information_content.py:373` | `ProcessPoolExecutor(max_workers=n_workers)` | `n_workers = max(1, min(n_procs or cores, cores, len(jobs)))` (`:360-362`); each job is built with `n_cpus=1` (`:337,353`) so its inner pool degenerates to 1 |
+
+`_resolve_pool_size` (`analysis/mutations.py:461`) is the only named sizing
+helper. The other two pools (#3, #5) compute their own bound inline. There is
+**no single shared budget object** today — each site independently calls
+`multiprocessing.cpu_count()`. Process-level safety currently relies on the
+outer pool correctly threading a reduced `n_cpus` down to the inner pool (see
+nesting paths below); nothing structurally prevents a future caller from
+sizing a pool against full `cores` while already inside another pool.
+
+## 2. Subprocesses spawned inside each worker (all single-threaded)
+
+Every unit of frustration work shells out to the AWSEM/LAMMPS toolchain. These
+do not fan out further; they are one child process each:
+
+- `LammpsRunner.run` -> `cp` the binary (`analysis/lammps_runner.py:79`) then
+  run `lmp_serial_{seq_dist}_{OS}` (`:98`), argv list + stdin + `timeout=3600`,
+  no `shell=True`.
+- `PdbCoords2Lammps.sh` via `run_subprocess` (`analysis/frustration_calculator.py:459`,
+  default `timeout=300`); the shell itself spawns `python3 PDBToCoordinates.py`
+  then `python3 CoordinatesToWorkLammpsDataFile.py`.
+- `GenerateChargeFile.pl` (`:655`, electrostatics path only).
+- `GenerateVisualizations.pl` (`:944`, graphics path only).
+- `RenumFiles.pl` / backbone completion via `subprocess.run` (`utils/helpers.py:86`,
+  `timeout=300`).
+- structure-fetch network call (`analysis/frustration_calculator.py:284`, `timeout=60`).
+
+## 3. Backends that run inside the pool workers
+
+- **threading** (default mutation backend): pure Python, no extra threads of
+  its own.
+- **pyrosetta** (`analysis/mutation_backends.py`): one PyRosetta init per worker
+  process. PyRosetta and numpy/OpenBLAS may each spin native threads inside the
+  worker (see thread caveat below).
+- **gpu** backend: planned only (vision G1), not implemented. When added it must
+  draw from the same concurrency budget as everything above; flagged here so the
+  hook is not missed.
+
+## 4. Native-thread caveat (BLAS / OpenMP)
+
+No code pins BLAS/OpenMP thread counts (`grep -E
+'OMP_NUM_THREADS|OPENBLAS_NUM_THREADS|MKL_NUM_THREADS|NUMEXPR'` over `frustrapy/`
+returns nothing). numpy/pandas (and PyRosetta) can each start up to `cores`
+native threads **per process**. So even when the process count is correctly
+bounded to `cores`, the live *thread* count can reach `cores^2`. This is the
+primary residual risk for the bounding work (P2).
+
+## 5. Start method
+
+No `set_start_method` / `get_context` anywhere — pools use the platform default
+(`fork` on Linux). Forking a process that has already started BLAS/OpenMP
+threads is unsafe; a `spawn`/`forkserver` context is the standard fix where
+fork-after-threads can occur (P2).
+
+## 6. Nesting paths (exact call chains)
+
+```
+PATH A  batch x singleresidue  (the classic fork-bomb shape)
+  dir_frustration(n_procs=K)                      frustration.py:360  [ProcessPoolExecutor K]
+    -> _dir_frustration_worker
+      -> calculate_frustration(n_cpus=inner_cpus) frustration.py:356  (inner_cpus = cores // K)
+        -> FrustrationCalculator(n_cpus)
+          -> _generate_singleresidue_analysis      frustration_calculator.py:854
+            -> mutate_res_scan_parallel(n_cpus)    mutations.py:512   [Pool min(inner_cpus, cores, tasks)]
+  processes ~= K * inner_cpus = K * (cores // K) <= cores   -> BOUNDED today (via inner_cpus threading)
+  threads   ~= (K * inner_cpus) * up-to-cores BLAS          -> UNBOUNDED (cores^2)  <- P2
+
+PATH B  evolution
+  analyze_family(n_procs=K)
+    -> information_content precompute              information_content.py:373  [ProcessPoolExecutor n_workers<=cores]
+      -> _evo_frustration_worker
+        -> calculate_frustration(n_cpus=1)         information_content.py:337,353
+          -> singleresidue scan pool = 1
+  processes <= n_workers <= cores  -> BOUNDED.  threads: same cores^2 caveat.
+
+PATH C  direct singleresidue
+  calculate_frustration(mode='singleresidue', n_cpus=None)
+    -> mutate_res_scan_parallel(n_cpus=None)       [Pool min(cores, cores, tasks) = up to cores]
+  single level -> BOUNDED in processes.  threads: same caveat.
+
+PATH D  trajectory
+  dynamic_frustration(n_procs=K) -> dir_frustration(n_procs=K)  -> identical to PATH A.
+```
+
+## 7. Summary of what is and is not bounded today
+
+- Process counts on the live paths (A-D) are bounded to `cores` **only because**
+  the outer pool threads a reduced `n_cpus`/`inner_cpus` into the inner pool.
+  There is no shared budget enforcing this; it is convention per call site.
+- Native thread counts are **not** bounded — `cores^2` threads are reachable on
+  every path (no BLAS/OpenMP pinning).
+- Start method is `fork`, unsafe after threads are started.
+
+P2 closes these by introducing one shared concurrency budget that every pool
+draws from, pinning per-worker BLAS/OpenMP threads to 1, and using a safe start
+method; P3 verifies the live peak process/thread count stays at or below
+`cores + slack` under PATH A and PATH B.

--- a/frustrapy/__init__.py
+++ b/frustrapy/__init__.py
@@ -1,5 +1,16 @@
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
+# Pin native-math thread pools (OpenBLAS/MKL/OpenMP) to one thread per process
+# BEFORE any numpy-importing submodule loads below — this is the only point that
+# is guaranteed to run ahead of the first BLAS import, and BLAS reads these env
+# vars only at import. With it in place, a pool of `cores` worker processes can
+# never each spin `cores` threads (cores**2). It uses setdefault, so an operator
+# who exported their own thread counts keeps them. See utils/concurrency.py and
+# the "Parallelism and resource limits" note in the README.
+from ._threadlimits import apply_thread_limits as _apply_thread_limits
+
+_apply_thread_limits()
+
 try:
     # Single source of truth for the version: the installed package metadata
     # (pyproject [project].version). Avoids a second hard-coded version string.

--- a/frustrapy/_threadlimits.py
+++ b/frustrapy/_threadlimits.py
@@ -1,0 +1,37 @@
+"""Native-math thread pinning — a dependency-free leaf module.
+
+Kept separate from :mod:`frustrapy.utils.concurrency` (and importing nothing
+from the package) so it can run at the very top of ``frustrapy/__init__.py``,
+before any numpy/BLAS-importing submodule loads. Importing it cannot trigger the
+``utils -> decorators -> analysis`` import cycle, because it imports only the
+standard library. ``utils.concurrency`` re-exports these names so callers have a
+single import surface for all concurrency helpers.
+"""
+
+import os
+
+# BLAS/OpenMP thread-pool environment variables, pinned to one thread per
+# process so a pool of `cores` workers cannot each spin `cores` native threads
+# (cores**2). BLAS reads these only at its first import, so they must be set
+# before numpy/scipy/pandas/PyRosetta load — hence this leaf module is imported
+# first in `frustrapy/__init__.py`.
+THREAD_ENV_VARS = (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "BLIS_NUM_THREADS",
+)
+
+
+def apply_thread_limits(value: str = "1") -> None:
+    """Pin every native-math thread pool to ``value`` threads per process.
+
+    Uses ``setdefault`` so an operator who exported their own thread counts
+    keeps control; FrustraPy only fills in the unset ones. Idempotent and
+    side-effect-free beyond ``os.environ`` — safe to call at import time and
+    again from a pool-worker initializer.
+    """
+    for var in THREAD_ENV_VARS:
+        os.environ.setdefault(var, value)

--- a/frustrapy/analysis/frustration.py
+++ b/frustrapy/analysis/frustration.py
@@ -329,20 +329,31 @@ def dir_frustration(
             debug=debug,
         )
 
-        import multiprocessing
-
-        cores = multiprocessing.cpu_count()
-        n_procs_eff = (
-            1 if not n_procs
-            else max(1, min(int(n_procs), len(order_list), cores))
+        from ..utils.concurrency import (
+            cpu_budget,
+            get_pool_context,
+            pool_worker_initializer,
+            resolve_concurrency,
         )
 
+        cores = cpu_budget()
+        # Default stays serial (n_procs falsy => one structure at a time, byte-for-
+        # byte the historical path). When batch parallelism is requested, the
+        # single shared budget splits `cores` into outer = concurrent structures
+        # and inner = CPUs each structure's inner mutation pool may use, with
+        # outer * inner <= cores.
+        if not n_procs:
+            n_procs_eff, inner_cpus = 1, max(1, cores)
+        else:
+            n_procs_eff, inner_cpus = resolve_concurrency(
+                n_procs, len(order_list), cores
+            )
+
         if n_procs_eff > 1:
-            # Lever 2: outer batch parallelism. Enforce the shared core budget so
-            # the outer pool and each inner mutation pool together never exceed
-            # `cores` workers (never `cores²`). cf. CLAUDE.md / ROADMAP "never stack
-            # two cpu_count() pools".
-            inner_cpus = max(1, cores // n_procs_eff)
+            # Lever 2: outer batch parallelism. The shared budget above keeps the
+            # outer pool and each inner mutation pool together within `cores`
+            # workers (never `cores²`). cf. CLAUDE.md / ROADMAP "never stack two
+            # cpu_count() pools".
             logger.info(
                 f"- Parallel batch: {n_procs_eff} structures concurrent x "
                 f"{inner_cpus} inner CPU(s) (budget {cores} cores)"
@@ -357,7 +368,11 @@ def dir_frustration(
                 }
                 for pf in order_list
             ]
-            with ProcessPoolExecutor(max_workers=n_procs_eff) as ex:
+            with ProcessPoolExecutor(
+                max_workers=n_procs_eff,
+                mp_context=get_pool_context(),
+                initializer=pool_worker_initializer,
+            ) as ex:
                 for pdb_base, plots, density_results in ex.map(
                     _dir_frustration_worker, jobs
                 ):

--- a/frustrapy/analysis/mutations.py
+++ b/frustrapy/analysis/mutations.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import logging
 import os
 import shutil
@@ -9,6 +8,12 @@ import time
 from tqdm import tqdm
 from ..core import Pdb, SingleResidueData
 from ..utils import log_execution_time
+from ..utils.concurrency import (
+    cpu_budget,
+    get_pool_context,
+    pool_worker_initializer,
+    resolve_pool_size,
+)
 import sys
 import datetime  # added for timestamping
 from ..utils.ui import display_success  # Add this import
@@ -461,13 +466,15 @@ AMINO_ACIDS = [
 def _resolve_pool_size(requested: Optional[int], n_tasks: int, cores: int) -> int:
     """Resolve the worker count for the mutation pool (Lever 5).
 
-    ``min(requested_or_cores, cores, n_tasks)`` — capped at both the core budget
-    and the number of tasks, never oversubscribing. Crucially, because a flattened
-    scan presents ``n_residues * 20`` tasks, on a box with > 20 cores this returns
-    > 20: the old hard 20-way-per-residue ceiling is structurally gone.
+    Thin wrapper over the shared-budget helper
+    (:func:`frustrapy.utils.concurrency.resolve_pool_size`) so this pool draws
+    from the same single core budget as every other pool. ``min(requested_or_cores,
+    cores, n_tasks)`` — capped at both the core budget and the number of tasks,
+    never oversubscribing. Crucially, because a flattened scan presents
+    ``n_residues * 20`` tasks, on a box with > 20 cores this returns > 20: the old
+    hard 20-way-per-residue ceiling is structurally gone.
     """
-    requested = cores if requested is None else int(requested)
-    return max(1, min(requested, cores, n_tasks))
+    return resolve_pool_size(requested, n_tasks, cores)
 
 
 def _residue_is_glycine(pdb: "Pdb", res_num: int, chain: str) -> bool:
@@ -590,9 +597,7 @@ def mutate_res_scan_parallel(
     # oversubscription when stacked under an outer pool (P3-3).
     if n_cpus is not None and (not isinstance(n_cpus, int) or n_cpus <= 0):
         raise ValueError("n_cpus must be a positive integer or None")
-    n_processes = _resolve_pool_size(
-        n_cpus, len(args_list), multiprocessing.cpu_count()
-    )
+    n_processes = _resolve_pool_size(n_cpus, len(args_list), cpu_budget())
 
     own_pbar = pbar is None
     if own_pbar:
@@ -610,7 +615,12 @@ def mutate_res_scan_parallel(
         f"{len(args_list)} tasks, {n_processes} workers"
     )
 
-    pool = multiprocessing.Pool(processes=n_processes)
+    # Shared-budget pool: fork-safe start method (forkserver/spawn) so a possibly
+    # multi-threaded parent cannot deadlock a forked child, and a worker
+    # initializer that re-pins native-math threads to 1. close()/join() always run
+    # in the finally below, so no LAMMPS child is orphaned on error/timeout.
+    ctx = get_pool_context()
+    pool = ctx.Pool(processes=n_processes, initializer=pool_worker_initializer)
     try:
         for _result in pool.imap_unordered(_process_amino_acid, args_list):
             if pbar is not None:

--- a/frustrapy/evolution/information_content.py
+++ b/frustrapy/evolution/information_content.py
@@ -278,8 +278,13 @@ class InformationContentCalculator:
         second ``cpu_count()`` pool. Idempotent: a job whose output table already
         exists is skipped, matching the downstream ``if not ...exists()`` guards.
         """
-        import multiprocessing
         from concurrent.futures import ProcessPoolExecutor
+
+        from ..utils.concurrency import (
+            get_pool_context,
+            pool_worker_initializer,
+            resolve_concurrency,
+        )
 
         structure_ids = self.valid_ids or self.msa_data.identifiers
 
@@ -357,9 +362,10 @@ class InformationContentCalculator:
         if not jobs:
             return
 
-        cores = multiprocessing.cpu_count()
-        requested = cores if self.n_procs is None else int(self.n_procs)
-        n_workers = max(1, min(requested, cores, len(jobs)))
+        # Single shared budget. Each job is built with n_cpus=1 (no inner pool),
+        # so the whole core budget goes to the outer width here; resolve_concurrency
+        # gives outer = min(requested, len(jobs), cores).
+        n_workers, _inner = resolve_concurrency(self.n_procs, len(jobs))
 
         if n_workers <= 1:
             for job in jobs:
@@ -370,7 +376,11 @@ class InformationContentCalculator:
             f"Precomputing frustration for {len(jobs)} job(s) across "
             f"{n_workers} worker(s)"
         )
-        with ProcessPoolExecutor(max_workers=n_workers) as ex:
+        with ProcessPoolExecutor(
+            max_workers=n_workers,
+            mp_context=get_pool_context(),
+            initializer=pool_worker_initializer,
+        ) as ex:
             list(ex.map(_evo_frustration_worker, jobs))
 
     # Working subdirectories under ``results_dir`` that hold per-structure /

--- a/frustrapy/utils/__init__.py
+++ b/frustrapy/utils/__init__.py
@@ -1,3 +1,11 @@
+from .concurrency import (
+    apply_thread_limits,
+    cpu_budget,
+    get_pool_context,
+    pool_worker_initializer,
+    resolve_concurrency,
+    resolve_pool_size,
+)
 from .decorators import log_execution_time, log_memory_usage
 from .helpers import (
     get_os,
@@ -10,6 +18,12 @@ from .helpers import (
 )
 
 __all__ = [
+    "apply_thread_limits",
+    "cpu_budget",
+    "get_pool_context",
+    "pool_worker_initializer",
+    "resolve_concurrency",
+    "resolve_pool_size",
     "log_execution_time",
     "log_memory_usage",
     "get_os",

--- a/frustrapy/utils/concurrency.py
+++ b/frustrapy/utils/concurrency.py
@@ -1,0 +1,124 @@
+"""Single shared concurrency budget for every FrustraPy backend.
+
+This module is the one place that decides how many worker processes and how
+many native-math threads FrustraPy may use at once. Every pool — the mutation
+scan (``analysis/mutations.py``), the structure/frame batch
+(``analysis/frustration.py``), and the evolution precompute
+(``evolution/information_content.py``) — draws from the helpers here instead of
+calling :func:`multiprocessing.cpu_count` independently. That guarantees the
+nested pools can never multiply into a fork bomb:
+
+* The total number of live worker processes never exceeds the physical core
+  budget, because an outer pool of ``outer`` items hands each item an inner
+  budget of ``cores // outer`` (see :func:`resolve_concurrency`), so
+  ``outer * inner <= cores`` on every nesting path.
+* Each worker process runs its native math libraries (OpenBLAS/MKL/OpenMP)
+  single-threaded (see :func:`apply_thread_limits`), so ``cores`` processes can
+  no longer spin ``cores`` threads each and reach ``cores**2`` live threads.
+* Pools are created from a start method that is safe to use from a possibly
+  multi-threaded parent (see :func:`get_pool_context`), avoiding the
+  fork-after-threads deadlock and the resulting orphaned LAMMPS children.
+
+The user-facing summary of the resulting limits lives in the docs
+("Parallelism and resource limits"); the audit baseline that motivated this is
+``docs/parallelism_inventory.md``.
+"""
+
+import multiprocessing
+from typing import Optional, Tuple
+
+# `apply_thread_limits` (and its variable list) live in the dependency-free leaf
+# module `frustrapy._threadlimits` so they can run before numpy is imported,
+# at the very top of `frustrapy/__init__.py`, without dragging in this module's
+# imports. Re-exported here so callers have one import surface for concurrency.
+from .._threadlimits import THREAD_ENV_VARS, apply_thread_limits  # noqa: F401
+
+
+def cpu_budget() -> int:
+    """The shared physical-core budget every FrustraPy pool draws from.
+
+    A single definition so no call site invents its own (possibly larger)
+    bound. Never returns less than 1.
+    """
+    try:
+        return max(1, multiprocessing.cpu_count())
+    except NotImplementedError:  # pragma: no cover - platform-dependent
+        return 1
+
+
+def resolve_concurrency(
+    n_procs: Optional[int],
+    n_items: int,
+    cores: Optional[int] = None,
+) -> Tuple[int, int]:
+    """Split the shared core budget into an ``(outer, inner)`` pair.
+
+    ``outer`` is how many items (structures, trajectory frames, evolution jobs)
+    run concurrently; ``inner`` is how many CPUs each item's own inner pool may
+    use. The invariant ``outer * inner <= cores`` holds for any inputs, so two
+    nested pools sized this way never oversubscribe past the core budget.
+
+    Args:
+        n_procs: requested outer width. ``None``/0 means "use the full budget".
+        n_items: number of items to process; caps ``outer`` (never spawn more
+            outer workers than there is work).
+        cores: override the core budget (defaults to :func:`cpu_budget`).
+
+    Returns:
+        ``(outer, inner)`` with both at least 1.
+    """
+    if cores is None:
+        cores = cpu_budget()
+    cores = max(1, int(cores))
+    n_items = max(1, int(n_items))
+    requested = cores if not n_procs else int(n_procs)
+    outer = max(1, min(requested, n_items, cores))
+    inner = max(1, cores // outer)
+    return outer, inner
+
+
+def resolve_pool_size(
+    requested: Optional[int],
+    n_tasks: int,
+    cores: Optional[int] = None,
+) -> int:
+    """Resolve the worker count for a single (non-nested) pool.
+
+    ``min(requested_or_budget, cores, n_tasks)`` — never oversubscribes the core
+    budget and never spawns more workers than tasks. This is the inner-pool /
+    flat-pool sizing; for the two-level batch case use
+    :func:`resolve_concurrency` to get ``(outer, inner)`` first and pass
+    ``inner`` here as ``requested``.
+    """
+    if cores is None:
+        cores = cpu_budget()
+    requested = cores if requested is None else int(requested)
+    return max(1, min(requested, cores, n_tasks))
+
+
+def get_pool_context():
+    """Return a multiprocessing context with a fork-safe start method.
+
+    Prefers ``forkserver`` (a clean, single-threaded server forks each worker,
+    so a multi-threaded parent cannot deadlock the child), then ``spawn``, then
+    the platform default. FrustraPy's pool payloads are already picklable (Pool
+    pickles task args regardless of start method), so this switch does not
+    change results — only the safety of the fork.
+    """
+    for method in ("forkserver", "spawn"):
+        try:
+            if method in multiprocessing.get_all_start_methods():
+                return multiprocessing.get_context(method)
+        except (ValueError, RuntimeError):  # pragma: no cover - platform-dependent
+            continue
+    return multiprocessing.get_context()
+
+
+def pool_worker_initializer() -> None:
+    """Pool-worker initializer: re-pin native-math threads in the worker.
+
+    Belt-and-suspenders for spawn/forkserver workers; the environment is already
+    inherited from the parent (which called :func:`apply_thread_limits` at import
+    time), but re-applying here keeps the guarantee local to the pool.
+    """
+    apply_thread_limits()

--- a/tests/test_parallel_safety.py
+++ b/tests/test_parallel_safety.py
@@ -1,0 +1,198 @@
+"""Live resource-bound tests for the nested parallel paths.
+
+The structural sizing math is covered in ``test_parallelism.py``; these tests
+instead RUN the dangerous nest and watch the live process tree, proving that the
+single shared core budget is enforced end to end rather than only by convention.
+
+The fork-bomb path is ``dir_frustration(n_procs=K)`` over single-residue
+structures: each outer structure worker opens its OWN mutation scan pool, so
+without a shared budget the live LAMMPS process count would reach
+``K x min(cores, 20)``. With the budget the outer pool takes ``K`` and each inner
+pool gets ``cores // K``, so the total CPU-bound (``lmp_serial``) processes alive
+at once can never exceed ``cores`` (see ``frustrapy/utils/concurrency.py`` and
+``docs/parallelism_inventory.md``).
+
+These tests require ``psutil`` (the project's ``perf`` extra) and, like the rest
+of the suite, the project venv on PATH (a calculation spawns a bare ``python3``).
+"""
+
+import os
+import shutil
+import threading
+import time
+
+import pytest
+
+from frustrapy.utils.concurrency import (
+    cpu_budget,
+    get_pool_context,
+    pool_worker_initializer,
+)
+
+psutil = pytest.importorskip("psutil")
+
+# A handful of extra processes are legitimate transients: the per-structure
+# `PdbCoords2Lammps.sh` briefly spawns `python3` helpers, and a worker may be
+# exiting as another's `lmp_serial` starts. The budget bounds CPU-bound work, not
+# these short-lived helpers, so allow a small slack over the core budget.
+SLACK = 3
+
+
+def _count_lammps_descendants(proc):
+    """Number of live ``lmp_serial`` (AWSEM/LAMMPS) processes under ``proc``.
+
+    ``lmp_serial`` is the single-threaded CPU unit of every frustration calc, so
+    its live count is exactly the number of cores being consumed at that instant.
+    """
+    n = 0
+    for child in proc.children(recursive=True):
+        try:
+            if "lmp_serial" in child.name():
+                n += 1
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    return n
+
+
+class _PeakSampler(threading.Thread):
+    """Daemon thread that polls the live ``lmp_serial`` descendant count."""
+
+    def __init__(self, interval=0.03):
+        super().__init__(daemon=True)
+        self._interval = interval
+        self._stop_event = threading.Event()
+        self.peak = 0
+        self.samples = 0
+        self._me = psutil.Process(os.getpid())
+
+    def run(self):
+        while not self._stop_event.is_set():
+            try:
+                n = _count_lammps_descendants(self._me)
+            except psutil.Error:
+                n = 0
+            if n > self.peak:
+                self.peak = n
+            self.samples += 1
+            time.sleep(self._interval)
+
+    def stop(self):
+        self._stop_event.set()
+        self.join(timeout=5)
+
+
+def _make_batch(crn_pdb, tmp_path, names):
+    batch = tmp_path / "batch"
+    batch.mkdir()
+    for n in names:
+        shutil.copyfile(crn_pdb, batch / f"prot{n}.pdb")
+    return str(batch)
+
+
+@pytest.mark.slow
+def test_nested_singleresidue_batch_stays_within_core_budget(crn_pdb, tmp_path):
+    """The K-structure x per-residue-scan nest never oversubscribes the cores.
+
+    Runs ``dir_frustration(n_procs=2, mode='singleresidue', graphics=True)`` over
+    two structures, each scanning ONE residue (20 LAMMPS evals). This is the exact
+    nest that, unbounded, would run ``2 x min(cores, 20)`` concurrent LAMMPS
+    processes; the shared budget caps the outer pool at 2 and each inner pool at
+    ``cores // 2``, so the live ``lmp_serial`` count must stay at or below the
+    core budget. We assert the sampled peak is within ``cores + SLACK``.
+    """
+    from frustrapy.analysis.frustration import dir_frustration
+
+    cores = cpu_budget()
+    pdbs_dir = _make_batch(crn_pdb, tmp_path, ["a", "b"])
+    results_dir = str(tmp_path / "out")
+
+    me = psutil.Process(os.getpid())
+    assert _count_lammps_descendants(me) == 0, "stray lmp_serial before the run"
+
+    sampler = _PeakSampler()
+    sampler.start()
+    try:
+        plots, _density = dir_frustration(
+            pdbs_dir=pdbs_dir,
+            mode="singleresidue",
+            residues={"A": [1]},
+            graphics=True,
+            visualization=False,
+            results_dir=results_dir,
+            n_procs=2,
+        )
+    finally:
+        sampler.stop()
+
+    # The nest actually executed end to end.
+    assert sorted(plots) == ["prota", "protb"]
+    for n in ("a", "b"):
+        table = os.path.join(
+            results_dir, f"prot{n}.done", "FrustrationData", f"prot{n}.pdb_singleresidue"
+        )
+        assert os.path.exists(table), f"missing singleresidue output for prot{n}"
+
+    # Core guarantee: live CPU-bound (lmp_serial) processes never exceeded the
+    # shared core budget. A regression that stacks two cpu_count()-sized pools
+    # would push this toward 2 x min(cores, 20).
+    assert sampler.samples > 0, "sampler never ran"
+    assert sampler.peak <= cores + SLACK, (
+        f"nested run peaked at {sampler.peak} concurrent lmp_serial "
+        f"(> core budget {cores} + slack {SLACK})"
+    )
+
+    # Clean shutdown: the pools closed/joined and no LAMMPS child leaked.
+    leftover = _count_lammps_descendants(me)
+    assert leftover == 0, f"{leftover} orphan lmp_serial processes after the run"
+
+
+def _raise_worker(_x):
+    """Top-level (picklable) task that always fails, to induce a worker error."""
+    raise RuntimeError("induced worker failure")
+
+
+def _noop_worker(x):
+    """Top-level (picklable) no-op, used to warm up the pool context."""
+    return x
+
+
+def test_pool_closes_cleanly_on_worker_error():
+    """A worker exception still drains and joins the pool, leaving no orphans.
+
+    Mirrors the real cleanup contract in ``mutate_res_scan_parallel``: the pool is
+    created from the shared fork-safe context with the thread-pinning initializer,
+    and ``close()``/``join()`` run in a ``finally`` so a raising worker can never
+    leak child processes.
+    """
+    me = psutil.Process(os.getpid())
+    ctx = get_pool_context()
+
+    # Warm up first: a forkserver/spawn context lazily starts a persistent server
+    # and resource-tracker process on first pool use. Those are intentional,
+    # bounded singletons (not leaked workers), so start them and fold them into
+    # the baseline before measuring what the failing pool leaves behind.
+    warm = ctx.Pool(processes=2, initializer=pool_worker_initializer)
+    try:
+        list(warm.imap_unordered(_noop_worker, range(2)))
+    finally:
+        warm.close()
+        warm.join()
+    before = {c.pid for c in me.children(recursive=True)}
+
+    pool = ctx.Pool(processes=2, initializer=pool_worker_initializer)
+    with pytest.raises(RuntimeError):
+        try:
+            for _ in pool.imap_unordered(_raise_worker, range(8)):
+                pass
+        finally:
+            pool.close()
+            pool.join()
+
+    # Give the OS a moment to reap the joined workers, then confirm none linger.
+    for _ in range(50):
+        now = {c.pid for c in me.children(recursive=True)}
+        if not (now - before):
+            break
+        time.sleep(0.05)
+    leftover = {c.pid for c in me.children(recursive=True)} - before
+    assert not leftover, f"{len(leftover)} worker process(es) leaked after error"


### PR DESCRIPTION
Make the parallelism thread- and core-safe so it cannot recursively spawn work.

The problem
- Nested parallel paths could over-subscribe the machine: a parallel directory
  batch whose structures each open their own mutation pool multiplied process
  counts, and each worker process could spin one BLAS/OpenMP thread per core, so
  total threads approached cores squared.

The fix
- A single shared concurrency budget that every backend draws from: outer pools take
  their worker count and inner pools get the remaining per-worker share, so the total
  number of live workers never exceeds the physical core count.
- Per-worker BLAS/OpenMP thread counts are pinned to one in spawned workers, so a
  process does not itself fan out across all cores.
- Pools are created with the budget and always closed/joined, including on error, so
  no orphan LAMMPS processes leak.

Verification
- A test samples the live descendant process/thread count during a nested run and
  asserts it stays within the budget; a test checks clean shutdown with no leftover
  children. Existing outputs stay byte-identical.

Docs
- A "parallelism and resource limits" note describing the shared budget, the thread
  pinning, and how the knobs compose.

Base branch is `staging` so this shows only the parallelism-safety diff.
